### PR TITLE
Add support for SimpleForm.

### DIFF
--- a/app/assets/javascripts/jquery.pwdcalc.js
+++ b/app/assets/javascripts/jquery.pwdcalc.js
@@ -5,13 +5,13 @@
  * https://github.com/trimentor/pwdcalc/blob/master/LICENSE
  */
 $(function () {
-    $("li.pwdcalc").each(function () {
+    $("li.pwdcalc, div.pwdcalc_simple").each(function () {
         var pwdcalc, passwordStrengthMeter, passwordField, passwordScore;
 
         pwdcalc = $(this);
         passwordStrengthMeter = $('.pwdcalc', pwdcalc);
-        passwordField = $('#' + passwordStrengthMeter.data('field'));
-        passwordScore = passwordField.next(".pwdcalc-score");
+        passwordField = $('input', pwdcalc);
+        passwordScore = $('.pwdcalc-score', pwdcalc);
 
         $(this).closest('form').submit(function (event) {
             $(document).trigger('pwdcalc-submit', [event, passwordField]);

--- a/lib/pwdcalc.rb
+++ b/lib/pwdcalc.rb
@@ -1,4 +1,5 @@
 require "pwdcalc/helpers/hints"
+require 'pwdcalc/password_strength'
 
 module Pwdcalc
   # Required for jquery.YAPSM.min.js and jquery.pwdcalc.js to be discoverable in the asset pipeline
@@ -8,10 +9,13 @@ module Pwdcalc
     end
 
     initializer "pwdcalc.initialize" do
-
       # Add custom input to Formtastic if it's included in Gemfile
       if defined?(Formtastic)
         require 'pwdcalc/formtastic'
+      end
+
+      if defined?(SimpleForm)
+        require 'pwdcalc/simple_form'
       end
 
       ActionView::Base.send :include, Pwdcalc::Helpers::Hints

--- a/lib/pwdcalc/formtastic.rb
+++ b/lib/pwdcalc/formtastic.rb
@@ -4,6 +4,7 @@ module Formtastic
 
       include Base
       include Base::Stringish
+      include Pwdcalc::PasswordStrength
 
       def to_html
         input_wrapping do
@@ -12,18 +13,6 @@ module Formtastic
           password_strength_score <<
           password_strength_meter
         end
-      end
-
-      def password_strength_score
-        template.content_tag(:div, :class => "pwdcalc-score") do
-          template.content_tag(:span) do
-            template.content_tag(:b, "")
-          end
-        end
-      end
-
-      def password_strength_meter
-        template.content_tag(:p, "", :'data-field' => input_html_options[:id], :class => "password-strength-meter pwdcalc")
       end
     end
   end

--- a/lib/pwdcalc/password_strength.rb
+++ b/lib/pwdcalc/password_strength.rb
@@ -1,0 +1,15 @@
+module Pwdcalc
+  module PasswordStrength
+    def password_strength_score
+      template.content_tag(:div, :class => "pwdcalc-score") do
+        template.content_tag(:span) do
+          template.content_tag(:b, "")
+        end
+      end
+    end
+
+    def password_strength_meter
+      template.content_tag(:p, "", :'data-field' => input_html_options[:id], :class => "password-strength-meter pwdcalc")
+    end
+  end
+end

--- a/lib/pwdcalc/simple_form.rb
+++ b/lib/pwdcalc/simple_form.rb
@@ -1,0 +1,10 @@
+class PwdcalcSimpleInput < SimpleForm::Inputs::Base
+  include Pwdcalc::PasswordStrength
+
+  def input
+    add_size!
+    @builder.password_field(attribute_name, input_html_options) <<
+    password_strength_score <<
+    password_strength_meter
+  end
+end


### PR DESCRIPTION
The type needs to be called :pwdcalc_simple to avoid a nameclash when using both Formtastic and SimpleForm.
